### PR TITLE
Alias TCP_KEEPIDLE to TCP_KEEPALIVE for MacOS

### DIFF
--- a/tcp-keepalive-test.c
+++ b/tcp-keepalive-test.c
@@ -10,6 +10,9 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 
+#ifdef __APPLE__
+#define TCP_KEEPIDLE TCP_KEEPALIVE
+#endif
 
 int do_connect(struct sockaddr_in *dst, int keepalive_time) {
     int s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);


### PR DESCRIPTION
MacOS uses TCP_KEEPALIVE rather than TCP_KEEPIDLE, causing the build to fail. In this small program, a conditional alias may suffice.

Tested and working on MacOS (11.0.1) with Apple clang 12.0.0

fixes #1