### PR TITLE
Adding time-stamping to output

### DIFF
--- a/tcp-keepalive-test.c
+++ b/tcp-keepalive-test.c
@@ -10,6 +10,8 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 
+#include "util.h"
+
 #ifdef __APPLE__
 #define TCP_KEEPIDLE TCP_KEEPALIVE
 #endif
@@ -86,8 +88,8 @@ int main(int argc, char *argv[]){
             return EXIT_FAILURE;
         }
     }
-    printf("\n[+] All connections established\n");
-    fflush(stdout);
+    printf("\n");
+    msg("[+] All connections established\n");
 
     // select() loop
     for (;;) {
@@ -104,13 +106,12 @@ int main(int argc, char *argv[]){
             openconnections++;
         }
         if (openconnections == 0) {
-            printf("[+] No more alive connections left\n");
+            msg("[+] No more alive connections left\n");
             return EXIT_SUCCESS;
         }
 
-        printf("[+] Waiting for a connection to timeout.\n");
-        printf("[+] Open connections: %d\n", openconnections);
-        fflush(stdout);
+        msg("[+] Waiting for a connection to timeout.\n");
+        msg("[+] Open connections: %d\n", openconnections);
 
         ret = select(maxfd + 1, &rfds, NULL, NULL, NULL);
         if (ret == -1) {
@@ -123,7 +124,7 @@ int main(int argc, char *argv[]){
                 if (tcpsessions[i] != -1 && FD_ISSET(tcpsessions[i], &rfds)) {
                     ssize_t readret = read(tcpsessions[i], &buf, 1);
                     if (readret != -1 || errno != ETIMEDOUT) {
-                        printf("[-] shouldn't happen:\n"
+                        msg("[-] shouldn't happen:\n"
                                 "readret: %ld\n"
                                 "errno: %d (%m)\n"
                                 "i: %d\n"
@@ -134,16 +135,16 @@ int main(int argc, char *argv[]){
                         tcpsessions[i] = -1;
                         continue;
                     }
-                    printf("[+] TCP connection died: ");
+                    msg("[+] TCP connection died: ");
                     printf("Connection %d, keepalivetime: %dm %ds\n",
                             i, keepalivetime[i]/60, keepalivetime[i]%60);
-                    close(tcpsessions[i]);
                     fflush(stdout);
+                    close(tcpsessions[i]);
                     tcpsessions[i] = -1;
                 }
             }
         } else {
-            printf("[+] No data\n");
+            msg("[+] No data\n");
         }
     }
 

--- a/tcp-keepalive-test.c
+++ b/tcp-keepalive-test.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]){
         }
     }
     printf("\n[+] All connections established\n");
-
+    fflush(stdout);
 
     // select() loop
     for (;;) {
@@ -109,8 +109,9 @@ int main(int argc, char *argv[]){
         }
 
         printf("[+] Waiting for a connection to timeout.\n");
-        printf("[+] Open connections: %d\n",
-                openconnections);
+        printf("[+] Open connections: %d\n", openconnections);
+        fflush(stdout);
+
         ret = select(maxfd + 1, &rfds, NULL, NULL, NULL);
         if (ret == -1) {
             if (errno == EINTR)
@@ -137,6 +138,7 @@ int main(int argc, char *argv[]){
                     printf("Connection %d, keepalivetime: %dm %ds\n",
                             i, keepalivetime[i]/60, keepalivetime[i]%60);
                     close(tcpsessions[i]);
+                    fflush(stdout);
                     tcpsessions[i] = -1;
                 }
             }
@@ -147,4 +149,3 @@ int main(int argc, char *argv[]){
 
     return 0;
 }
-

--- a/tcp-recv-test.c
+++ b/tcp-recv-test.c
@@ -45,7 +45,6 @@ int do_connect(struct sockaddr_in *dst) {
 int main(int argc, char *argv[]){
     int tcpsessions[NCONNECTIONS] = {0};
     int serversleeptime[NCONNECTIONS] = {0};
-    char buf;
     char aint[64] = {0};
     int ret;
     time_t startup_time = time(NULL);

--- a/tcp-recv-test.c
+++ b/tcp-recv-test.c
@@ -89,8 +89,9 @@ int main(int argc, char *argv[]){
         }
 
         printf("[+] Waiting for the server to close a connection\n");
-        printf("[+] Open connections: %d\n",
-                openconnections);
+        printf("[+] Open connections: %d\n", openconnections);
+        fflush(stdout);
+
         ret = select(maxfd + 1, &rfds, NULL, NULL, NULL);
         if (ret == -1) {
             if (errno == EINTR)
@@ -113,10 +114,12 @@ int main(int argc, char *argv[]){
                     } else if (readret > 0) {
                         aint[readret] = '\0';
                         time_t alivetime = time(NULL) - startup_time;
-                        printf("[+] Connection %d returned after %ldm %lds: %s\n", i, alivetime/60, alivetime%60, aint);
+                        printf("[+] Connection %d returned after %ldm %lds: %s\n",
+                               i, alivetime/60, alivetime%60, aint);
                     } else {
                         printf("[-] Shouldn't happen. Connection %d\n", i);
                     }
+                    fflush(stdout);
 
                     close(tcpsessions[i]);
                     tcpsessions[i] = -1;

--- a/tcp-recv-test.c
+++ b/tcp-recv-test.c
@@ -26,7 +26,7 @@ int do_connect(struct sockaddr_in *dst) {
     }
 
 /* for faster debugging
-    // specifies the maximum amount of time in milliseconds 
+    // specifies the maximum amount of time in milliseconds
     // that transmitted data may remain unacknowledged before
     // TCP will forcibly close the corresponding connection
     // and return ETIMEDOUT to the application.
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]){
     }
 
     printf("\n[+] All connections established\n");
-    
+
     // select() loop
     for (;;) {
         fd_set rfds;
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]){
                         time_t alivetime = time(NULL) - startup_time;
                         printf("[+] Connection %d returned after %ldm %lds: %s\n", i, alivetime/60, alivetime%60, aint);
                     } else {
-                        printf("[-] Shoudln't happen. Connection %d\n", i);
+                        printf("[-] Shouldn't happen. Connection %d\n", i);
                     }
 
                     close(tcpsessions[i]);

--- a/tcp-send-test.c
+++ b/tcp-send-test.c
@@ -10,6 +10,7 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 
+#include "util.h"
 
 int do_connect(struct sockaddr_in *dst) {
     int s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -49,7 +50,7 @@ int main(int argc, char *argv[]){
         .sin_addr   = inet_addr("130.225.254.111"),
     };
 
-    printf("[+] Trying to establish connections: ");
+    msg("[+] Trying to establish connections: ");
     for (int i = 0; i < NCONNECTIONS; i++) {
         printf("%d ", i);
         fflush(stdout);
@@ -58,9 +59,9 @@ int main(int argc, char *argv[]){
             return EXIT_FAILURE;
         }
     }
+    printf("\n");
 
-    printf("\n[+] All connections established\n");
-    fflush(stdout);
+    msg("[+] All connections established\n");
 
     for (int i = 0; i < NCONNECTIONS; i++) {
         // This is not exact - we'll gradually drift
@@ -71,8 +72,7 @@ int main(int argc, char *argv[]){
                 perror("write");
                 return EXIT_FAILURE;
             }
-            printf("[-] Connection %d is dead (write)\n", i);
-            fflush(stdout);
+            msg("[-] Connection %d is dead (write)\n", i);
             close(tcpsessions[i]);
             continue;
         }
@@ -82,14 +82,11 @@ int main(int argc, char *argv[]){
                 perror("read");
                 return EXIT_FAILURE;
             }
-            printf("[-] Connection %d is dead (read)\n", i);
-            fflush(stdout);
+            msg("[-] Connection %d is dead (read)\n", i);
             close(tcpsessions[i]);
             continue;
         }
-
-        printf("[+] Connection %d worked\n", i);
-        fflush(stdout);
+        msg("[+] Connection %d worked\n", i);
 
         close(tcpsessions[i]);
     }

--- a/tcp-send-test.c
+++ b/tcp-send-test.c
@@ -24,7 +24,7 @@ int do_connect(struct sockaddr_in *dst) {
     }
 
 /* for faster debugging
-    // specifies the maximum amount of time in milliseconds 
+    // specifies the maximum amount of time in milliseconds
     // that transmitted data may remain unacknowledged before
     // TCP will forcibly close the corresponding connection
     // and return ETIMEDOUT to the application.
@@ -60,6 +60,7 @@ int main(int argc, char *argv[]){
     }
 
     printf("\n[+] All connections established\n");
+    fflush(stdout);
 
     for (int i = 0; i < NCONNECTIONS; i++) {
         // This is not exact - we'll gradually drift
@@ -71,6 +72,7 @@ int main(int argc, char *argv[]){
                 return EXIT_FAILURE;
             }
             printf("[-] Connection %d is dead (write)\n", i);
+            fflush(stdout);
             close(tcpsessions[i]);
             continue;
         }
@@ -81,11 +83,13 @@ int main(int argc, char *argv[]){
                 return EXIT_FAILURE;
             }
             printf("[-] Connection %d is dead (read)\n", i);
+            fflush(stdout);
             close(tcpsessions[i]);
             continue;
         }
 
         printf("[+] Connection %d worked\n", i);
+        fflush(stdout);
 
         close(tcpsessions[i]);
     }

--- a/tcp-send-test.c
+++ b/tcp-send-test.c
@@ -43,7 +43,6 @@ int do_connect(struct sockaddr_in *dst) {
 int main(int argc, char *argv[]){
     int tcpsessions[NCONNECTIONS] = {0};
     char buf;
-    int ret;
     struct sockaddr_in dst_addr = {
         .sin_family = AF_INET,
         .sin_port   = htons(31415),

--- a/util.h
+++ b/util.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0+
+#ifndef __UTIL_H
+#define __UTIL_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <sys/time.h>
+
+void msg(const char* format, ... )
+{
+	struct timeval tv = {};
+	va_list arglist;
+
+	gettimeofday(&tv, NULL);
+
+	printf("[%-.8ld.%-.6ld] ",  tv.tv_sec, tv.tv_usec);
+	va_start(arglist, format);
+	vprintf(format, arglist);
+	va_end(arglist);
+	fflush(stdout);
+}
+
+#endif /* __UTIL_H */


### PR DESCRIPTION
This PR primary adds time-stamping to the output, in the same way conntrack tool does timestamping.

This makes it easier to correlate conntrack events on the NAT server with test tool output.

The conntrack tool can track real-time events via this command and also filter on the events like this:
```
 conntrack -E -o extended,timestamp -d 130.225.254.111
```